### PR TITLE
Update read_sav_region with additional functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .Rproj.user
 .Rhistory
 .RData
+_install
+_build

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -19,13 +19,15 @@ read_sav_header <- function(file_path) {
 
 #' Reads the specified region from a SAV file.
 #' @param path SAV file path.
+#' @param samples Which samples to extract.
 #' @param chrom Chromosome to query.
 #' @param beg Start position.
 #' @param end End position.
+#' @param tranpose Whether or not to transpose the genotype data.
 #' @param fmt Whether to read data as genotypes, allele counts, haplotype dosages, dosages or genotype probabilities (GT, AC, HDS, DS, GP, Default: GT).
 #' @return A data frame of site info and a matrix of genotype data.
 #' @export
-read_sav_region <- function(file_path, chrom, beg, end, fmt_str = "GT") {
-    .Call('_savr_read_sav_region', PACKAGE = 'savr', file_path, chrom, beg, end, fmt_str)
+read_sav_region <- function(file_path, samples, chrom, beg, end, transpose = FALSE, fmt_str = "GT") {
+    .Call('_savr_read_sav_region', PACKAGE = 'savr', file_path, samples, chrom, beg, end, transpose, fmt_str)
 }
 

--- a/configure
+++ b/configure
@@ -3,8 +3,7 @@ set -e
 pip install --user cget
 
 #rm -rf _build
-
-$(which cget) install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
+$(python -m site --user-base)/bin/cget install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
 
 cmake -H. -B_build \
     -DCMAKE_TOOLCHAIN_FILE=_build/cget/cget.cmake \
@@ -15,3 +14,4 @@ cmake -H. -B_build \
 cmake --build _build --target install --config Release
 
 cp _install/lib/savr.so src/ || (>&2 echo "Failed: savr.so -> src")
+cp _install/lib/savr.dylib src/savr.so || (>&2 echo "Failed: savr.dylib -> src")

--- a/configure
+++ b/configure
@@ -7,8 +7,6 @@ pip install --user cget
 $(which cget) install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
 
 cmake -H. -B_build \
-    -DCMAKE_CXX_COMPILER=$CXX \
-    -DCMAKE_C_COMPILER=$CC \
     -DCMAKE_TOOLCHAIN_FILE=_build/cget/cget.cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=_install \

--- a/configure
+++ b/configure
@@ -4,10 +4,7 @@ pip install --user cget
 
 #rm -rf _build
 
-CXX=$(which g++)
-CC=$(which gcc)
-
-$(which cget) install -DCGET_PREFIX=/net/sandbox/home/alexrix -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
+$(which cget) install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
 
 cmake -H. -B_build \
     -DCMAKE_CXX_COMPILER=$CXX \

--- a/configure
+++ b/configure
@@ -3,9 +3,15 @@ set -e
 pip install --user cget
 
 #rm -rf _build
-$(python -m site --user-base)/bin/cget install -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
+
+CXX=$(which g++)
+CC=$(which gcc)
+
+$(which cget) install -DCGET_PREFIX=/net/sandbox/home/alexrix -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" --prefix _build statgen/savvy@a41d1f03c77047544b6901552ba6df61fa14f322
 
 cmake -H. -B_build \
+    -DCMAKE_CXX_COMPILER=$CXX \
+    -DCMAKE_C_COMPILER=$CC \
     -DCMAKE_TOOLCHAIN_FILE=_build/cget/cget.cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=_install \
@@ -14,4 +20,3 @@ cmake -H. -B_build \
 cmake --build _build --target install --config Release
 
 cp _install/lib/savr.so src/ || (>&2 echo "Failed: savr.so -> src")
-cp _install/lib/savr.dylib src/savr.so || (>&2 echo "Failed: savr.dylib -> src")

--- a/man/read_sav_region.Rd
+++ b/man/read_sav_region.Rd
@@ -4,9 +4,12 @@
 \alias{read_sav_region}
 \title{Reads the specified region from a SAV file.}
 \usage{
-read_sav_region(file_path, chrom, beg, end, fmt_str = "GT")
+read_sav_region(file_path, samples, chrom, beg, end, transpose = FALSE,
+  fmt_str = "GT")
 }
 \arguments{
+\item{samples}{Which samples to extract.}
+
 \item{chrom}{Chromosome to query.}
 
 \item{beg}{Start position.}
@@ -14,6 +17,8 @@ read_sav_region(file_path, chrom, beg, end, fmt_str = "GT")
 \item{end}{End position.}
 
 \item{path}{SAV file path.}
+
+\item{tranpose}{Whether or not to transpose the genotype data.}
 
 \item{fmt}{Whether to read data as genotypes, allele counts, haplotype dosages, dosages or genotype probabilities (GT, AC, HDS, DS, GP, Default: GT).}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -28,17 +28,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_sav_region
-Rcpp::List read_sav_region(const std::string& file_path, const std::string& chrom, std::int32_t beg, std::int32_t end, const std::string& fmt_str);
-RcppExport SEXP _savr_read_sav_region(SEXP file_pathSEXP, SEXP chromSEXP, SEXP begSEXP, SEXP endSEXP, SEXP fmt_strSEXP) {
+Rcpp::List read_sav_region(const std::string& file_path, std::vector<std::string>& samples, const std::string& chrom, std::int32_t beg, std::int32_t end, bool transpose, const std::string& fmt_str);
+RcppExport SEXP _savr_read_sav_region(SEXP file_pathSEXP, SEXP samplesSEXP, SEXP chromSEXP, SEXP begSEXP, SEXP endSEXP, SEXP transposeSEXP, SEXP fmt_strSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type file_path(file_pathSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string>& >::type samples(samplesSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type chrom(chromSEXP);
     Rcpp::traits::input_parameter< std::int32_t >::type beg(begSEXP);
     Rcpp::traits::input_parameter< std::int32_t >::type end(endSEXP);
+    Rcpp::traits::input_parameter< bool >::type transpose(transposeSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type fmt_str(fmt_strSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_sav_region(file_path, chrom, beg, end, fmt_str));
+    rcpp_result_gen = Rcpp::wrap(read_sav_region(file_path, samples, chrom, beg, end, transpose, fmt_str));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -46,7 +48,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_savr_stat_sav_file", (DL_FUNC) &_savr_stat_sav_file, 1},
     {"_savr_read_sav_header", (DL_FUNC) &_savr_read_sav_header, 1},
-    {"_savr_read_sav_region", (DL_FUNC) &_savr_read_sav_region, 5},
+    {"_savr_read_sav_region", (DL_FUNC) &_savr_read_sav_region, 7},
     {NULL, NULL, 0}
 };
 

--- a/src/savr.cpp
+++ b/src/savr.cpp
@@ -178,14 +178,10 @@ Rcpp::List read_sav_region(const std::string& file_path, std::vector<std::string
   std::vector<std::string> alt_alleles(nrows);
 
   Rcpp::NumericMatrix geno_data;
-  if (transpose) {
-      Rcpp::Rcout << "r: " << ncols << " c: " << nrows << "\n";
+  if (transpose)
       geno_data = Rcpp::NumericMatrix(ncols, nrows);
-  }
-  else {
-      Rcpp::Rcout << "r: " << nrows << " c: " << ncols << "\n";
+  else
       geno_data = Rcpp::NumericMatrix(nrows, ncols);
-  }
 
   std::vector<std::vector<std::string>> info_columns(file.info_fields().size(), std::vector<std::string>(nrows));
 

--- a/src/savr.cpp
+++ b/src/savr.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <list>
 
-
 //' Get statistics about SAV file.
 //' @param path SAV file path.
 //' @return A data frame of statistics about file.
@@ -27,9 +26,9 @@ Rcpp::List stat_sav_file(const std::string& file_path)
   std::vector<std::int32_t> variant_counts(nrows);
   std::vector<std::int32_t> min_positions(nrows);
   std::vector<std::int32_t> max_positions(nrows);
-  
+
   std::vector<std::string> column_names(4);
-  column_names[0] = "chromosome"; 
+  column_names[0] = "chromosome";
   column_names[1] = "variant_count";
   column_names[2] = "min_position";
   column_names[3] = "max_position";
@@ -37,7 +36,7 @@ Rcpp::List stat_sav_file(const std::string& file_path)
   std::size_t i = 0;
   for (auto it = index_file.trees_begin(); it != index_file.trees_end(); ++it,++i)
   {
-    // chromosome 
+    // chromosome
     chromosomes[i] = it->name();
 
     // marker count
@@ -52,14 +51,14 @@ Rcpp::List stat_sav_file(const std::string& file_path)
     std::uint32_t min;
     std::uint32_t max;
     std::tie(min, max) = it->range();
-    
+
     // min pos
     min_positions[i] = min;
 
     // max pos
     max_positions[i] = max;
   }
-  
+
   Rcpp::List ret(4);
   ret[0] = std::move(chromosomes);
   ret[1] = std::move(variant_counts);
@@ -69,7 +68,7 @@ Rcpp::List stat_sav_file(const std::string& file_path)
   ret.attr("names") = column_names;
   ret.attr("class") = "data.frame";
   ret.attr("row.names") = Rcpp::IntegerVector::create(NA_INTEGER, -nrows);
-  
+
   return ret;
 }
 
@@ -83,13 +82,13 @@ Rcpp::List read_sav_header(const std::string& file_path)
 {
   savvy::sav::reader r(file_path, savvy::fmt::gt);
   if (!r.good())
-  { 
+  {
     Rcpp::stop("Could not open SAV file (" + file_path + ")");
   }
-  
+
   std::vector<std::string> header_names(r.headers().size());
   std::vector<std::string> header_values(r.headers().size());
-  
+
   std::size_t i = 0;
   for (auto it = r.headers().begin(); it != r.headers().end(); ++it,++i)
   {
@@ -98,7 +97,7 @@ Rcpp::List read_sav_header(const std::string& file_path)
   }
 
   Rcpp::List ret;
-  ret["headers"] = Rcpp::DataFrame::create( 
+  ret["headers"] = Rcpp::DataFrame::create(
     Rcpp::Named("name") = std::move(header_names),
     Rcpp::Named("value") = std::move(header_values),
     Rcpp::Named("stringsAsFactors") = false);
@@ -110,15 +109,17 @@ Rcpp::List read_sav_header(const std::string& file_path)
 
 //' Reads the specified region from a SAV file.
 //' @param path SAV file path.
+//' @param samples Which samples to extract.
 //' @param chrom Chromosome to query.
 //' @param beg Start position.
 //' @param end End position.
+//' @param tranpose Whether or not to transpose the genotype data.
 //' @param fmt Whether to read data as genotypes, allele counts, haplotype dosages, dosages or genotype probabilities (GT, AC, HDS, DS, GP, Default: GT).
 //' @return A data frame of site info and a matrix of genotype data.
 //' @export
 // [[Rcpp::export]]
-Rcpp::List read_sav_region(const std::string& file_path, const std::string& chrom, std::int32_t beg, std::int32_t end, const std::string& fmt_str = "GT")
-{ 
+Rcpp::List read_sav_region(const std::string& file_path, std::vector<std::string>& samples, const std::string& chrom, std::int32_t beg, std::int32_t end, bool transpose = false, const std::string& fmt_str = "GT")
+{
   savvy::fmt fmt = savvy::fmt::gt;
   if (fmt_str == "AC")
     fmt = savvy::fmt::ac;
@@ -128,38 +129,64 @@ Rcpp::List read_sav_region(const std::string& file_path, const std::string& chro
     fmt = savvy::fmt::ds;
   else if (fmt_str == "GP")
     fmt = savvy::fmt::gp;
-    
+
   std::list<savvy::variant<savvy::compressed_vector<float>>> tmp_vars(1);
   savvy::sav::indexed_reader file(file_path, {chrom, static_cast<std::uint64_t>(beg), static_cast<std::uint64_t>(end)}, fmt);
   if (!file.good())
-  { 
+  {
     Rcpp::stop("Could not open indexed SAV file (" + file_path + ")");
   }
 
-  while (file >> tmp_vars.back()) 
+  // extract only the samples the user wants
+  auto sav_samples = file.subset_samples({samples.begin(), samples.end()});
+
+  // check to see the both vectors contain the same elements
+  if (sav_samples.size() != samples.size())
+    Rcpp::stop("samples contains IDs that are not in the sav file.");
+
+  // sav file probably is not storing the samples in the same order as the
+  // input, so generate an order vector that will be used to fill in the
+  // genotype matrix acoording to the user's order.
+  std::vector<int> order(samples.size());
+  for (int j = 0; j < sav_samples.size(); ++j) {
+      for (int i = 0; i < samples.size(); ++i)
+        if (sav_samples[j] == samples[i])
+            order[j] = i;
+  }
+
+  while (file >> tmp_vars.back())
     tmp_vars.emplace_back();
 
   if (file.bad())
-  { 
+  {
     Rcpp::stop("I/O error (" + file_path + ")");
   }
 
   tmp_vars.pop_back();
   std::size_t nrows = tmp_vars.size();
   std::size_t ncols;
-  if (fmt == savvy::fmt::gt || fmt == savvy::fmt::hds)  
-    ncols = file.samples().size() * (file.ploidy() ? file.ploidy() : 2);
+  if (fmt == savvy::fmt::gt || fmt == savvy::fmt::hds)
+    ncols = samples.size() * (file.ploidy() ? file.ploidy() : 2);
   else if (fmt == savvy::fmt::gp)
-    ncols = file.samples().size() * ((file.ploidy() ? file.ploidy() : 2) + 1);
+    ncols = samples.size() * ((file.ploidy() ? file.ploidy() : 2) + 1);
   else
-    ncols = file.samples().size();
+    ncols = samples.size();
 
   std::vector<std::string> chromosomes(nrows);
   std::vector<std::int32_t> positions(nrows);
   std::vector<std::string> ref_alleles(nrows);
   std::vector<std::string> alt_alleles(nrows);
 
-  Rcpp::NumericMatrix geno_data(nrows, ncols);
+  Rcpp::NumericMatrix geno_data;
+  if (transpose) {
+      Rcpp::Rcout << "r: " << ncols << " c: " << nrows << "\n";
+      geno_data = Rcpp::NumericMatrix(ncols, nrows);
+  }
+  else {
+      Rcpp::Rcout << "r: " << nrows << " c: " << ncols << "\n";
+      geno_data = Rcpp::NumericMatrix(nrows, ncols);
+  }
+
   std::vector<std::vector<std::string>> info_columns(file.info_fields().size(), std::vector<std::string>(nrows));
 
   std::size_t i = 0;
@@ -169,7 +196,7 @@ Rcpp::List read_sav_region(const std::string& file_path, const std::string& chro
     positions[i] = it->position();
     ref_alleles[i] = it->ref();
     alt_alleles[i] = it->alt();
-    
+
     std::size_t j = 0;
     for (auto jt = file.info_fields().begin(); jt != file.info_fields().end(); ++jt,++j)
     {
@@ -177,24 +204,29 @@ Rcpp::List read_sav_region(const std::string& file_path, const std::string& chro
     }
 
     if (ncols != it->data().size())
-    { 
+    {
       Rcpp::stop("Logic Error: variant vector size (" + std::to_string(it->data().size()) + ") does not match matrix row size (" + std::to_string(ncols) + ")");
     }
+
+    j = 0;
     auto jt_end = it->data().end();
     for (auto jt = it->data().begin(); jt != jt_end; ++jt)
     {
-      geno_data(i, jt.offset()) = *jt;
+      if (transpose)
+        geno_data(order[jt.offset()], i) = *jt;
+      else
+        geno_data(i, order[jt.offset()]) = *jt;
     }
   }
-  
+
   Rcpp::List result;
-  
+
   std::vector<std::string> column_names;
   column_names.reserve(4 + file.info_fields().size());
   column_names = {"chrom","pos", "ref", "alt"};
   for (auto it = file.info_fields().begin(); it != file.info_fields().end(); ++it)
     column_names.push_back(*it);
-  
+
   Rcpp::List columns(4 + file.info_fields().size());
 
   // Hack thanks to Matthew Flickinger
@@ -213,7 +245,12 @@ Rcpp::List read_sav_region(const std::string& file_path, const std::string& chro
   }
 
   result["variants"] = columns;
-  
+
+  Rcpp::CharacterVector sample_ids = Rcpp::wrap(samples);
+  if (transpose)
+    geno_data.attr("dimnames") = Rcpp::List::create(sample_ids, columns["ID"]);
+  else
+    geno_data.attr("dimnames") = Rcpp::List::create(columns["ID"], sample_ids);
   result["data"] = std::move(geno_data);
 
   return result;


### PR DESCRIPTION
This PR changes the way `read_sav_region` works by requiring the user to input which samples  (people) they want, provides the option to transpose the genotype matrix, and also gives the genotype matrix the appropriate row and column names.

So, the updated function signature is
```
read_sav_region <- function(file_path, samples, chrom, beg, end, transpose = FALSE,  
                                fmt_str = "GT")
```

To accomplish this added I some code to perform the matrix transposition and making sure the genotype matrix is ordered according to the order of the `samples` argument.

I tested the code on the GxE analysis I've been running on MGI data. These changes reduced memory usage of the analysis by approximately 50%.

Other information:

I made some changes to `configure` so it tries using `$(which cget)` when trying to install savvy instead of `$(python -m site --user-base)/bin/cget`. I think that this package will be used on CSG for the most part, so it should be okay. I also removed the .dylib copy at the end as it generates an (harmless) error message on Linux systems and I'm not sure what the use is for this on MacOS.

Let me know if you want any extra info,

Alex Rix